### PR TITLE
Auto connect USB on startup

### DIFF
--- a/src/USB/USBHub.cpp
+++ b/src/USB/USBHub.cpp
@@ -49,7 +49,7 @@ void USBHub::start(Promise::Pointer promise)
         if(self_ == nullptr)
         {
             self_ = this->shared_from_this();
-            hotplugHandle_ = usbWrapper_.hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS, LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
+            hotplugHandle_ = usbWrapper_.hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_ENUMERATE, LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
                                                                  LIBUSB_HOTPLUG_MATCH_ANY, reinterpret_cast<libusb_hotplug_callback_fn>(&USBHub::hotplugEventsHandler), reinterpret_cast<void*>(this));
         }
     });


### PR DESCRIPTION
Previous behavior was to connect Android Auto when a phone is plugged in to USB. On app startup, if the phone was already plugged in you had to unplug it and plug it back in for it to connect.

This changes the behavior to connect on startup if it's already plugged in.
