### PR TITLE
Manual merge of commits from OpenCarDev aasdk

### DIFF
--- a/include/aasdk/Messenger/Cryptor.hpp
+++ b/include/aasdk/Messenger/Cryptor.hpp
@@ -37,7 +37,7 @@ public:
     void deinit() override;
     bool doHandshake() override;
     size_t encrypt(common::Data& output, const common::DataConstBuffer& buffer) override;
-    size_t decrypt(common::Data& output, const common::DataConstBuffer& buffer) override;
+    size_t decrypt(common::Data& output, const common::DataConstBuffer& buffer, int length) override;
 
     common::Data readHandshakeBuffer() override;
     void writeHandshakeBuffer(const common::DataConstBuffer& buffer) override;

--- a/include/aasdk/Messenger/FrameSize.hpp
+++ b/include/aasdk/Messenger/FrameSize.hpp
@@ -35,7 +35,8 @@ public:
     FrameSize(const common::DataConstBuffer& buffer);
 
     common::Data getData() const;
-    size_t getSize() const;
+    size_t getFrameSize() const;
+    size_t getTotalSize() const;
 
     static size_t getSizeOf(FrameSizeType type);
 

--- a/include/aasdk/Messenger/ICryptor.hpp
+++ b/include/aasdk/Messenger/ICryptor.hpp
@@ -39,7 +39,7 @@ public:
     virtual void deinit() = 0;
     virtual bool doHandshake() = 0;
     virtual size_t encrypt(common::Data& output, const common::DataConstBuffer& buffer) = 0;
-    virtual size_t decrypt(common::Data& output, const common::DataConstBuffer& buffer) = 0;
+    virtual size_t decrypt(common::Data& output, const common::DataConstBuffer& buffer, int length) = 0;
     virtual common::Data readHandshakeBuffer() = 0;
     virtual void writeHandshakeBuffer(const common::DataConstBuffer& buffer) = 0;
     virtual bool isActive() const = 0;

--- a/include/aasdk/Messenger/MessageInStream.hpp
+++ b/include/aasdk/Messenger/MessageInStream.hpp
@@ -49,10 +49,16 @@ private:
     boost::asio::io_service::strand strand_;
     transport::ITransport::Pointer transport_;
     ICryptor::Pointer cryptor_;
-    FrameType recentFrameType_;
+
+    FrameType thisFrameType_;
     ReceivePromise::Pointer promise_;
+    ReceivePromise::Pointer interleavedPromise_;
     Message::Pointer message_;
+
     std::map<messenger::ChannelId, Message::Pointer> messageBuffer_;
+
+    int frameSize_;
+    bool isValidFrame_;
 };
 
 }

--- a/include/aasdk/Messenger/Messenger.hpp
+++ b/include/aasdk/Messenger/Messenger.hpp
@@ -57,6 +57,7 @@ private:
     ChannelReceivePromiseQueue channelReceivePromiseQueue_;
     ChannelReceiveMessageQueue channelReceiveMessageQueue_;
     ChannelSendQueue channelSendPromiseQueue_;
+
 };
 
 }

--- a/src/Messenger/FrameSize.cpp
+++ b/src/Messenger/FrameSize.cpp
@@ -47,6 +47,7 @@ FrameSize::FrameSize(const common::DataConstBuffer& buffer)
     {
         frameSizeType_ = FrameSizeType::SHORT;
         frameSize_ = boost::endian::big_to_native(reinterpret_cast<const uint16_t&>(buffer.cdata[0]));
+        totalSize_ = frameSize_;
     }
 
     if(buffer.size >= 6)
@@ -74,10 +75,16 @@ common::Data FrameSize::getData() const
     return data;
 }
 
-size_t FrameSize::getSize() const
+size_t FrameSize::getFrameSize() const
 {
     return frameSize_;
 }
+
+size_t FrameSize::getTotalSize() const
+{
+    return totalSize_;
+}
+
 
 size_t FrameSize::getSizeOf(FrameSizeType type)
 {

--- a/src/Messenger/FrameType.cpp
+++ b/src/Messenger/FrameType.cpp
@@ -16,26 +16,29 @@
 *  along with aasdk. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
-
-#include <stdint.h>
-#include <string>
-
+#include <aasdk/Messenger/FrameType.hpp>
 
 namespace aasdk
 {
-namespace messenger
-{
+    namespace messenger
+    {
 
-enum class FrameType
-{
-    MIDDLE = 0,
-    FIRST = 1 << 0,
-    LAST = 1 << 1,
-    BULK = FIRST | LAST
-};
+        std::string frameTypeToString(FrameType frameType)
+        {
+            switch(frameType)
+            {
+                case FrameType::MIDDLE:
+                    return "MIDDLE";
+                case FrameType::FIRST:
+                    return "FIRST";
+                case FrameType::LAST:
+                    return "LAST";
+                case FrameType::BULK:
+                    return "BULK";
+                default:
+                    return "(null)";
+            }
+        }
 
-std::string frameTypeToString(FrameType frameType);
-
-}
+    }
 }

--- a/src/Messenger/MessageInStream.cpp
+++ b/src/Messenger/MessageInStream.cpp
@@ -18,7 +18,8 @@
 
 #include <aasdk/Messenger/MessageInStream.hpp>
 #include <aasdk/Error/Error.hpp>
-
+#include <aasdk/Common/Log.hpp>
+#include <iostream>
 
 namespace aasdk
 {
@@ -36,24 +37,20 @@ MessageInStream::MessageInStream(boost::asio::io_service& ioService, transport::
 void MessageInStream::startReceive(ReceivePromise::Pointer promise)
 {
     strand_.dispatch([this, self = this->shared_from_this(), promise = std::move(promise)]() mutable {
-        if(promise_ == nullptr)
-        {
+        if (promise_ == nullptr) {
             promise_ = std::move(promise);
-
             auto transportPromise = transport::ITransport::ReceivePromise::defer(strand_);
             transportPromise->then(
-                [this, self = this->shared_from_this()](common::Data data) mutable {
-                    this->receiveFrameHeaderHandler(common::DataConstBuffer(data));
-                },
-                [this, self = this->shared_from_this()](const error::Error& e) mutable {
-                    promise_->reject(e);
-                    promise_.reset();
-                });
+                    [this, self = this->shared_from_this()](common::Data data) mutable {
+                        this->receiveFrameHeaderHandler(common::DataConstBuffer(data));
+                    },
+                    [this, self = this->shared_from_this()](const error::Error &e) mutable {
+                        promise_->reject(e);
+                        promise_.reset();
+                    });
 
             transport_->receive(FrameHeader::getSizeOf(), std::move(transportPromise));
-        }
-        else
-        {
+        } else {
             promise->reject(error::Error(error::ErrorCode::OPERATION_IN_PROGRESS));
         }
     });
@@ -63,32 +60,35 @@ void MessageInStream::receiveFrameHeaderHandler(const common::DataConstBuffer& b
 {
     FrameHeader frameHeader(buffer);
 
-    if(message_ != nullptr && message_->getChannelId() != frameHeader.getChannelId())
-    {
-        messageBuffer_[message_->getChannelId()] = message_;
-        message_ = nullptr;
-    }
+    AASDK_LOG(debug) << "[MessageInStream] Processing Frame Header: Ch " << channelIdToString(frameHeader.getChannelId()) << " Fr " << frameTypeToString(frameHeader.getType());
+
+    isValidFrame_ = true;
 
     auto bufferedMessage = messageBuffer_.find(frameHeader.getChannelId());
+    if (bufferedMessage != messageBuffer_.end()) {
+        // We have found a message...
+        message_ = std::move(bufferedMessage->second);
+        messageBuffer_.erase(bufferedMessage);
 
-    if(bufferedMessage != messageBuffer_.end())
-    {
-        if(frameHeader.getType() != FrameType::FIRST)
-        {
-            message_ = bufferedMessage->second;
-        }
-        else
-        {
+        AASDK_LOG(debug) << "[MessageInStream] Found existing message.";
+
+        if (frameHeader.getType() == FrameType::FIRST || frameHeader.getType() == FrameType::BULK) {
+            // If it's first or bulk, we need to override the message anyhow, so we will start again.
+            // Need to start a new message anyhow
             message_ = std::make_shared<Message>(frameHeader.getChannelId(), frameHeader.getEncryptionType(), frameHeader.getMessageType());
         }
-        messageBuffer_.erase(bufferedMessage);
-    }
-    else if(message_ == nullptr)
-    {
+    } else {
+        AASDK_LOG(debug) << "[MessageInStream] Could not find existing message.";
+        // No Message Found in Buffers and this is a middle or last frame, this an error.
+        // Still need to process the frame, but we will not resolve at the end.
         message_ = std::make_shared<Message>(frameHeader.getChannelId(), frameHeader.getEncryptionType(), frameHeader.getMessageType());
+        if (frameHeader.getType() == FrameType::MIDDLE || frameHeader.getType() == FrameType::LAST) {
+            // This is an error
+            isValidFrame_ = false;
+        }
     }
 
-    recentFrameType_ = frameHeader.getType();
+    thisFrameType_ = frameHeader.getType();
     const size_t frameSize = FrameSize::getSizeOf(frameHeader.getType() == FrameType::FIRST ? FrameSizeType::EXTENDED : FrameSizeType::SHORT);
 
     auto transportPromise = transport::ITransport::ReceivePromise::defer(strand_);
@@ -119,7 +119,8 @@ void MessageInStream::receiveFrameSizeHandler(const common::DataConstBuffer& buf
         });
 
     FrameSize frameSize(buffer);
-    transport_->receive(frameSize.getSize(), std::move(transportPromise));
+    frameSize_ = (int) frameSize.getFrameSize();
+    transport_->receive(frameSize.getFrameSize(), std::move(transportPromise));
 }
 
 void MessageInStream::receiveFramePayloadHandler(const common::DataConstBuffer& buffer)
@@ -128,7 +129,7 @@ void MessageInStream::receiveFramePayloadHandler(const common::DataConstBuffer& 
     {
         try
         {
-            cryptor_->decrypt(message_->getPayload(), buffer);
+            cryptor_->decrypt(message_->getPayload(), buffer, frameSize_);
         }
         catch(const error::Error& e)
         {
@@ -143,23 +144,34 @@ void MessageInStream::receiveFramePayloadHandler(const common::DataConstBuffer& 
         message_->insertPayload(buffer);
     }
 
-    if(recentFrameType_ == FrameType::BULK || recentFrameType_ == FrameType::LAST)
+    bool isResolved = false;
+
+    // If this is the LAST frame or a BULK frame...
+    if((thisFrameType_ == FrameType::BULK || thisFrameType_ == FrameType::LAST) && isValidFrame_)
     {
+        AASDK_LOG(debug) << "[MessageInStream] Resolving message.";
         promise_->resolve(std::move(message_));
         promise_.reset();
+        isResolved = true;
+
+        currentMessageIndex_--;
+    } else {
+        // First or Middle message, we'll store in our buffer...
+        messageBuffer_[message_->getChannelId()] = std::move(message_);
     }
-    else
-    {
+
+    // If the main promise isn't resolved, then carry on retrieving frame headers.
+    if (!isResolved) {
         auto transportPromise = transport::ITransport::ReceivePromise::defer(strand_);
         transportPromise->then(
-            [this, self = this->shared_from_this()](common::Data data) mutable {
-                this->receiveFrameHeaderHandler(common::DataConstBuffer(data));
-            },
-            [this, self = this->shared_from_this()](const error::Error& e) mutable {
-                message_.reset();
-                promise_->reject(e);
-                promise_.reset();
-            });
+                [this, self = this->shared_from_this()](common::Data data) mutable {
+                    this->receiveFrameHeaderHandler(common::DataConstBuffer(data));
+                },
+                [this, self = this->shared_from_this()](const error::Error& e) mutable {
+                    message_.reset();
+                    promise_->reject(e);
+                    promise_.reset();
+                });
 
         transport_->receive(FrameHeader::getSizeOf(), std::move(transportPromise));
     }

--- a/src/Transport/SSLWrapper.cpp
+++ b/src/Transport/SSLWrapper.cpp
@@ -22,7 +22,7 @@
 #include <openssl/ssl.h>
 #include <openssl/conf.h>
 #include <aasdk/Transport/SSLWrapper.hpp>
-
+#include <aasdk/Common/Log.hpp>
 
 namespace aasdk
 {
@@ -48,6 +48,8 @@ SSLWrapper::~SSLWrapper()
     ERR_remove_state(0);
 #endif
     ERR_free_strings();
+    ERR_load_crypto_strings();
+    ERR_load_ERR_strings();
 }
 
 X509* SSLWrapper::readCertificate(const std::string& certificate)
@@ -187,6 +189,9 @@ int SSLWrapper::sslWrite(SSL *ssl, const void *buf, int num)
 
 int SSLWrapper::getError(SSL* ssl, int returnCode)
 {
+    while (auto err = ERR_get_error()) {
+        AASDK_LOG(error) << "[SSLWrapper] SSL Error " << ERR_error_string(err, NULL);
+    }
     return SSL_get_error(ssl, returnCode);
 }
 


### PR DESCRIPTION
Here are some changes that I've merged in the opencardev fork. I've manually mereged them with a branch that should be able to merge with opendsh. 
@icecube45 you seem to know your way around aasdk better than most so if you can review these.

These have been authored by @sjdean. 

* Swap getSize() to getFrameSize() and add totalSize() for completeness.
* Add SSL Error Logging
* Switch decrypt() to read the number of bytes from the frame size.
* Support FrameType descriptor
* Rework Message Handling
* Slight tweaks
- Add isInterleaved boolean
- If message is NULL and Frame Type is MIDDLE or LAST, then look for an existing message in buffer (if the message_ is null, then we need a FIRST or BULK frame)
- If message is still NULL, then we will create a new message, but recognise it as a valid frame ONLY if this is a FIRST or BULK frame because we cannot start on a MIDDLE or LAST.
- Rename recentFrameType to thisFrameType for more accuracy
- Only Resolve the Frame if the frame is BULK or LAST and the frame is valid.
- If the frame is interleaved, then we will use our interleavedPromise handler. Only resolve the main promise if the frame is not interleaved.
- Also reset message once resolved.
- Carry on reading if the original promise is not resolved (ie FIRST, MIDDLE, or Interleaved frame)
- Add some counters for debugging purposes.
* Reworked Message Handling
- Have adjusted the buffer mechanism so instead of using the buffer to store a message in the event of an interleaved frame, we basically perform all work on the buffer (albeit we take the existing message for the channel id from the buffer for the frame we're working on and write the message to the buffer if the message isn't resolved).
- Moved writing to buffer to receiveFramePayloadHandler() function if the message is BULK or LAST and therefore not resolved.
- Simplified receiveFrameHeaderHandler() so that we automatically try to find a message from the buffer and then createa message as necessary depending on the frame type.
- Excellent stability with no noticeable artefacts in audio after 1 hour.
- Removed majority of debugging after achieving stability.