### PR TITLE
Update SSLWrapper.cpp

### DIFF
--- a/src/Transport/SSLWrapper.cpp
+++ b/src/Transport/SSLWrapper.cpp
@@ -39,7 +39,11 @@ SSLWrapper::SSLWrapper()
 
 SSLWrapper::~SSLWrapper()
 {
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+    EVP_default_properties_enable_fips(nullptr, 0);
+#else
     FIPS_mode_set(0);
+#endif
     ENGINE_cleanup();
     CONF_modules_unload(1);
     EVP_cleanup();


### PR DESCRIPTION
OpenSSL 3.0 changed how you set enabling FIPS support. Added conditional check to enable compilation on this version.